### PR TITLE
add note model with title and content fields

### DIFF
--- a/backend/src/models/Notes.js
+++ b/backend/src/models/Notes.js
@@ -1,0 +1,19 @@
+import mongoose from "mongoose"
+
+const noteSchema = new mongoose.Schema({
+        title:{
+            type:String,
+            required:true,
+        },
+        content:{
+            type:String,
+            required:true,
+        }
+        },
+    {timestamps:true}
+
+);
+
+const Note=mongoose.model("Note",noteSchema);
+
+export default Note;


### PR DESCRIPTION
This PR introduces the Note Mongoose model to define the schema structure for storing notes in MongoDB.

Key changes:

Created noteSchema with the following fields:

title (String, required) — Title of the note.

content (String, required) — Main body/content of the note.

Enabled timestamps option to automatically store createdAt and updatedAt fields.

Registered the schema as a Mongoose model named "Note".

Exported the model for use in routes and controllers.